### PR TITLE
fix: use ProcessBuilder in ValueSource to avoid fatal CC error on process start failure

### DIFF
--- a/gradle/build-logic/src/main/kotlin/io/github/mymx2/plugin/spotless/SpotlessConfig.kt
+++ b/gradle/build-logic/src/main/kotlin/io/github/mymx2/plugin/spotless/SpotlessConfig.kt
@@ -42,7 +42,7 @@ internal fun Project.npmFile(path: String? = null): Provider<File> {
     val npmPath =
       if (!path.isNullOrBlank()) path
       else {
-        eagerDiskCache("npmExePath") { ExeFinder.findExePath(providers, layout, "npm").orEmpty() }
+        eagerDiskCache("npmExePath") { ExeFinder.findExePath(providers, layout, "npm").get() }
       }
     val npmFile =
       if (npmPath.isNotBlank()) {

--- a/gradle/build-logic/src/main/kotlin/io/github/mymx2/plugin/utils/ExeFinder.kt
+++ b/gradle/build-logic/src/main/kotlin/io/github/mymx2/plugin/utils/ExeFinder.kt
@@ -1,13 +1,61 @@
 package io.github.mymx2.plugin.utils
 
+import java.io.File
 import org.gradle.api.file.ProjectLayout
+import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+
+/** Parameters for [CommandOutputValueSource]. */
+interface CommandOutputParameters : ValueSourceParameters {
+  var commandLine: List<String>
+  var workingDir: String?
+}
+
+/**
+ * Configuration-cache-safe [ValueSource] that captures stdout of an external command.
+ *
+ * Uses [ProcessBuilder] (pure JVM) instead of Gradle's `ExecOperations.exec` inside `obtain()`.
+ * Both `providers.exec` and `ExecOperations.exec` are internally serialized as
+ * `ProcessOutputValueSource` by the configuration cache, which fails on Windows with UAC error 740
+ * when the target process cannot be started.
+ *
+ * ProcessBuilder bypasses Gradle's native process launcher (rubygrapefruit), so a start failure is
+ * just a catchable `IOException` rather than a fatal CC error.
+ *
+ * **Note**: gradle/gradle#38399 deprecates `ProcessBuilder.start()` at configuration time only
+ * *outside* `ValueSource` (see
+ * [comment](https://github.com/gradle/gradle/issues/38464#issuecomment-4924508565)). Using
+ * ProcessBuilder inside `obtain()` remains valid for the foreseeable future. Once Gradle provides a
+ * graceful error path inside `ProcessOutputValueSource` (tracked in gradle/gradle#38464), this
+ * workaround can be replaced with the official API.
+ */
+abstract class CommandOutputValueSource : ValueSource<String, CommandOutputParameters> {
+
+  override fun obtain(): String {
+    return try {
+      val process =
+        ProcessBuilder(parameters.commandLine)
+          .apply { parameters.workingDir?.let { directory(File(it)) } }
+          .redirectErrorStream(true)
+          .start()
+      val output = process.inputStream.bufferedReader().readText().trim()
+      process.waitFor()
+      output
+    } catch (_: Exception) {
+      // Gracefully handle process start failures (e.g. exe not on daemon PATH,
+      // Windows UAC error 740). Callers already handle empty results.
+      ""
+    }
+  }
+}
 
 /** exe finder */
 object ExeFinder {
 
   /**
-   * Find exe path
+   * Find exe path via a configuration-cache-safe [ValueSource].
    *
    * Uses absolute path for system commands (where.exe / which) to avoid PATH resolution failures in
    * the Gradle daemon, especially under configuration cache mode where the daemon process may not
@@ -16,27 +64,24 @@ object ExeFinder {
    * @param providers Gradle providers
    * @param layout Gradle layout
    * @param name exe name
-   * @return Exe path
+   * @return Provider of exe path (empty string if not found)
    */
-  fun findExePath(providers: ProviderFactory, layout: ProjectLayout, name: String): String? {
-    return runCatching {
-        val isWindows = org.gradle.internal.os.OperatingSystem.current().isWindows
-        val execCommand =
-          if (isWindows) listOf("C:\\Windows\\System32\\where.exe", name)
-          else listOf("/usr/bin/which", name)
-        val fullCommit =
-          providers
-            .exec {
-              isIgnoreExitValue = true
-              commandLine(execCommand)
-              workingDir = layout.projectDirectory.asFile
-            }
-            .standardOutput
-            .asText
-            .get()
-            .trim()
-        fullCommit.ifBlank { null }
+  fun findExePath(
+    providers: ProviderFactory,
+    layout: ProjectLayout,
+    name: String,
+  ): Provider<String> {
+    val isWindows = org.gradle.internal.os.OperatingSystem.current().isWindows
+    val execCommand =
+      if (isWindows) listOf("C:\\Windows\\System32\\where.exe", name)
+      else listOf("/usr/bin/which", name)
+    return providers
+      .of(CommandOutputValueSource::class.java) {
+        parameters {
+          commandLine = execCommand
+          workingDir = layout.projectDirectory.asFile.absolutePath
+        }
       }
-      .getOrNull()
+      .map { it.ifBlank { "" } }
   }
 }

--- a/gradle/build-logic/src/main/kotlin/io/github/mymx2/plugin/utils/VersionUtils.kt
+++ b/gradle/build-logic/src/main/kotlin/io/github/mymx2/plugin/utils/VersionUtils.kt
@@ -37,21 +37,22 @@ object VersionRange {
 
 object SemVerUtils {
 
-  /** return the short commit hash of the current Git commit. If not available, returns null. */
+  /**
+   * return the short commit hash of the current Git commit. If not available, returns "unknown".
+   */
   fun gitBuildMetadata(providers: ProviderFactory, layout: ProjectLayout): String {
     return runCatching {
-        val fullCommit =
+        val output =
           providers
-            .exec {
-              isIgnoreExitValue = true
-              commandLine("git", "rev-parse", "HEAD")
-              workingDir = layout.projectDirectory.asFile
+            .of(CommandOutputValueSource::class.java) {
+              parameters {
+                commandLine = listOf("git", "rev-parse", "HEAD")
+                workingDir = layout.projectDirectory.asFile.absolutePath
+              }
             }
-            .standardOutput
-            .asText
             .get()
             .trim()
-        fullCommit.ifBlank { "unknown" }
+        output.ifBlank { "unknown" }
       }
       .getOrDefault("unknown")
   }


### PR DESCRIPTION
## Background

`ProcessOutputValueSource` fails fatally when the target process cannot start (e.g. Windows UAC error 740). This blocks configuration cache storage even when the process failure is a recoverable environmental condition.

Upstream issue: https://github.com/gradle/gradle/issues/38464

## What this PR does

Replaces `providers.exec` calls inside `ValueSource.obtain()` with a custom `CommandOutputValueSource` that uses `ProcessBuilder` (pure JVM) to:

- Bypass Gradle's native process launcher (`rubygrapefruit`) — process start failures become catchable `IOException` instead of fatal CC errors
- Return an empty string on failure, allowing callers to degrade gracefully

## Affected files

- `ExeFinder.kt` — adds `CommandOutputValueSource`, changes `findExePath` to return `Provider<String>`
- `SpotlessConfig.kt` — updated to use `.get()` on the new Provider return type
- `VersionUtils.kt` — uses `CommandOutputValueSource` for `git rev-parse HEAD`

## Note

This PR is kept as a draft/reference. The workaround is valid per the [Gradle team's clarification](https://github.com/gradle/gradle/issues/38464#issuecomment-4924508565): the deprecation in gradle/gradle#38399 only covers `ProcessBuilder.start()` **outside** of `ValueSource.obtain()`. Once Gradle provides a graceful error path inside `ProcessOutputValueSource`, this workaround can be replaced with the official API.